### PR TITLE
fix MetaTags::TextNormalizer#strip_tags for Rails 4.2.0 (fixes #69)

### DIFF
--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -45,7 +45,14 @@ module MetaTags
     # @return [String] string with no HTML tags.
     #
     def self.strip_tags(string)
-      helpers.strip_tags(string)
+      # Fix strip_tags for Rails 4.2.0
+      # @see https://github.com/rails/rails/issues/18527
+      # @see https://github.com/rails/rails-html-sanitizer/issues/28
+      if defined?(Loofah)
+        Loofah.fragment(string).text(encode_special_chars: false)
+      else
+        helpers.strip_tags(string)
+      end
     end
 
     # This method returns a html safe string similar to what <tt>Array#join</tt>


### PR DESCRIPTION
With Rails 4.2, strips_tags("H&M") now returns "H&amp;M" instead of "H&M". Internally, Rails is now using the loofag library, which html encodes special characters like '&' by default.
